### PR TITLE
feat: add support for graalvm 21.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ are shown below):
 
 ```yaml
 # specify the underlying community jdk version
-# 17.0.7, 17.0.8, 20.0.1, 20.0.2 or 21.0.0
-graalvm_java_version: '21.0.0'
+# 17.0.7, 17.0.8, 20.0.1, 20.0.2, 21.0.0 or 21.0.2
+graalvm_java_version: '21.0.2'
 
 # Base installation directory for any GraalVM distribution
 graalvm_install_dir: '/opt/graalvm'
@@ -117,6 +117,7 @@ The following versions of graalvm community jdk are supported without any additi
 * 20.0.1
 * 20.0.2
 * 21.0.0
+* 21.0.2
 
 Supported architectures
 -----------------------
@@ -136,7 +137,7 @@ By default this role will install the latest GraalVM CE that has been tested and
 # results:
 # new file /etc/profile.d/graalvm.sh
 # content:
-# GRAALVM_HOME=/opt/graalvm/jdk-21.0.0
+# GRAALVM_HOME=/opt/graalvm/jdk-21.0.2
 # PATH=${GRAALVM_HOME}/bin:${PATH}
 ```
 
@@ -178,7 +179,7 @@ You can install the multiple versions of the GraalVM by using this role more tha
       graalvm_is_default_installation: false
       graalvm_fact_group_name: 'graalvm_java_17_0_7'
 
-    # the second role install graalvm-community-jdk-21.0.0 and is set as default GraalVM
+    # the second role install graalvm-community-jdk-21.0.2 and is set as default GraalVM
     - role: arolfes.graalvm
 ```
 
@@ -186,15 +187,15 @@ To perform an offline install, you need to specify a bit more information (i.e. 
 
 ```yaml
 # Before performing the offline install, download
-# `graalvm-community-jdk-21.0.0_linux-x64_bin.tar.gz` to
+# `graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz` to
 # `{{ playbook_dir }}/files/` on the local machine.
 - hosts: servers
   roles:
     - role: arolfes.graalvm
-      graalvm_java_version: '21.0.0'
+      graalvm_java_version: '21.0.2'
       graalvm_use_local_archive: true
-      graalvm_redis_filename: 'graalvm-community-jdk-21.0.0_linux-x64_bin.tar.gz'
-      graalvm_redis_sha256sum: '7627a40c11341f743e3d937efe4fd3115b18bb3ca39380513b31d6775512d5b0'
+      graalvm_redis_filename: 'graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz'
+      graalvm_redis_sha256sum: 'b048069aaa3a99b84f5b957b162cc181a32a4330cbc35402766363c5be76ae48'
 ```
 
 Role Facts
@@ -204,11 +205,11 @@ This role exports the following Ansible facts for use by other roles:
 
 * `ansible_local.graalvm.general.java_version`
 
-    * e.g. `21.0.0`
+    * e.g. `21.0.2`
 
 * `ansible_local.graalvm.general.home`
 
-    * e.g. `/opt/graalvm/jdk-21.0.0`
+    * e.g. `/opt/graalvm/jdk-21.0.2`
 
 Overriding `graalvm_fact_group_name` will change the names of the facts e.g.:
 

--- a/create_sha256_files.sh
+++ b/create_sha256_files.sh
@@ -3,8 +3,10 @@ sha256sum ~/Downloads/graalvm-community-jdk-17.0.8_linux-x64_bin.tar.gz > vars/v
 sha256sum ~/Downloads/graalvm-community-jdk-20.0.1_linux-x64_bin.tar.gz > vars/versions/20.0.1_x64.yml
 sha256sum ~/Downloads/graalvm-community-jdk-20.0.2_linux-x64_bin.tar.gz > vars/versions/20.0.2_x64.yml
 sha256sum ~/Downloads/graalvm-community-jdk-21.0.0_linux-x64_bin.tar.gz > vars/versions/21.0.0_x64.yml
+sha256sum ~/Downloads/graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz > vars/versions/21.0.2_x64.yml
 sha256sum ~/Downloads/graalvm-community-jdk-17.0.7_linux-aarch64_bin.tar.gz > vars/versions/17.0.7_aarch64.yml
 sha256sum ~/Downloads/graalvm-community-jdk-17.0.8_linux-aarch64_bin.tar.gz > vars/versions/17.0.8_aarch64.yml
 sha256sum ~/Downloads/graalvm-community-jdk-20.0.1_linux-aarch64_bin.tar.gz > vars/versions/20.0.1_aarch64.yml
 sha256sum ~/Downloads/graalvm-community-jdk-20.0.2_linux-aarch64_bin.tar.gz > vars/versions/20.0.2_aarch64.yml
 sha256sum ~/Downloads/graalvm-community-jdk-21.0.0_linux-aarch64_bin.tar.gz > vars/versions/21.0.0_aarch64.yml
+sha256sum ~/Downloads/graalvm-community-jdk-21.0.2_linux-aarch64_bin.tar.gz > vars/versions/21.0.2_aarch64.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # specify the underlying community jdk version
-# 17.0.7, 17.0.8, 20.0.1, 20.0.2 or 21.0.0
-graalvm_java_version: '21.0.0'
+# 17.0.7, 17.0.8, 20.0.1, 20.0.2, 21.0.0 or 21.0.2
+graalvm_java_version: '21.0.2'
 
 # Base installation directory for any GraalVM distribution
 graalvm_install_dir: '/opt/graalvm'

--- a/molecule/fedora-min-graalvm-two-times/converge.yml
+++ b/molecule/fedora-min-graalvm-two-times/converge.yml
@@ -23,9 +23,9 @@
       assert:
         that:
           - ansible_local.graalvm.general.java_version is defined
-          - ansible_local.graalvm.general.java_version is version('21.0.0', '==')
+          - ansible_local.graalvm.general.java_version is version('21.0.2', '==')
           - ansible_local.graalvm.general.home is defined
-          - ansible_local.graalvm.general.home is match ('/opt/graalvm/jdk-21.0.0')
+          - ansible_local.graalvm.general.home is match ('/opt/graalvm/jdk-21.0.2')
 
     - name: install find - required for tests (dnf)
       dnf:

--- a/molecule/graalvm-max-offline/converge.yml
+++ b/molecule/graalvm-max-offline/converge.yml
@@ -18,8 +18,8 @@
 
     - name: download GraalVM for offline install
       get_url:
-        url: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.0/graalvm-community-jdk-21.0.0_linux-x64_bin.tar.gz"
-        dest: '{{ graalvm_local_archive_dir }}/graalvm-ce-jdk-21.0.0.tar.gz'
+        url: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz"
+        dest: '{{ graalvm_local_archive_dir }}/graalvm-ce-jdk-21.0.2.tar.gz'
         force: no
         timeout: '{{ graalvm_download_timeout_seconds }}'
         mode: 'u=rw,go=r'
@@ -27,19 +27,19 @@
 
   roles:
     - role: ansible-role-graalvm
-      graalvm_java_version: '21.0.0'
+      graalvm_java_version: '21.0.2'
       graalvm_use_local_archive: true
-      graalvm_redis_filename: 'graalvm-ce-jdk-21.0.0.tar.gz'
-      graalvm_redis_sha256sum: '6c422941ccc58be5b891bb6499feeb72cd2b74d6729a29bf1fb8cc1a7d58b319'
+      graalvm_redis_filename: 'graalvm-ce-jdk-21.0.2.tar.gz'
+      graalvm_redis_sha256sum: 'b048069aaa3a99b84f5b957b162cc181a32a4330cbc35402766363c5be76ae48'
 
   post_tasks:
     - name: verify graalvm facts
       assert:
         that:
           - ansible_local.graalvm.general.java_version is defined
-          - ansible_local.graalvm.general.java_version is version('21.0.0', '==')
+          - ansible_local.graalvm.general.java_version is version('21.0.2', '==')
           - ansible_local.graalvm.general.home is defined
-          - ansible_local.graalvm.general.home is match ('/opt/graalvm/jdk-21.0.0')
+          - ansible_local.graalvm.general.home is match ('/opt/graalvm/jdk-21.0.2')
 
     - name: install find - required for tests (dnf)
       dnf:

--- a/molecule/graalvm-max-online/converge.yml
+++ b/molecule/graalvm-max-online/converge.yml
@@ -17,9 +17,9 @@
       ansible.builtin.assert:
         that:
           - ansible_local.graalvm.general.java_version is defined
-          - ansible_local.graalvm.general.java_version is version('21.0.0', '==')
+          - ansible_local.graalvm.general.java_version is version('21.0.2', '==')
           - ansible_local.graalvm.general.home is defined
-          - ansible_local.graalvm.general.home is match ('/opt/graalvm/jdk-21.0.0')
+          - ansible_local.graalvm.general.home is match ('/opt/graalvm/jdk-21.0.2')
 
     - name: Install find - required for tests (dnf)
       ansible.builtin.dnf:

--- a/tasks/graalvm.yml
+++ b/tasks/graalvm.yml
@@ -7,7 +7,7 @@
 - name: Assert java version supported
   ansible.builtin.assert:
     that:
-      - graalvm_java_version in ('17.0.7', '17.0.8', '20.0.1', '20.0.2', '21.0.0')
+      - graalvm_java_version in ('17.0.7', '17.0.8', '20.0.1', '20.0.2', '21.0.0', '21.0.2')
 
 - name: graalvm_architecture
   ansible.builtin.debug:

--- a/vars/versions/21.0.2_aarch64.yml
+++ b/vars/versions/21.0.2_aarch64.yml
@@ -1,0 +1,2 @@
+# SHA256 sum for the redistributable package
+redis_sha256sum: 'a34be691ce68f0acf4655c7c6c63a9a49ed276a11859d7224fd94fc2f657cd7a'

--- a/vars/versions/21.0.2_x64.yml
+++ b/vars/versions/21.0.2_x64.yml
@@ -1,0 +1,2 @@
+# SHA256 sum for the redistributable package
+redis_sha256sum: 'b048069aaa3a99b84f5b957b162cc181a32a4330cbc35402766363c5be76ae48'


### PR DESCRIPTION
Hi @arolfes,
we would like to use the latest GraalVM JDK 21 release, which is 21.0.2 at the moment. I hope the pr contains all the relevant changes.